### PR TITLE
Update Go version

### DIFF
--- a/.github/workflows/go-cross.yml
+++ b/.github/workflows/go-cross.yml
@@ -11,7 +11,7 @@ jobs:
 
     strategy:
       matrix:
-        go-version: [ 1.19, 1.x ]
+        go-version: [ 1.23, 1.x ]
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
     name: Main Process
     runs-on: ubuntu-latest
     env:
-      GO_VERSION: 1.19
+      GO_VERSION: 1.23
       GOLANGCI_LINT_VERSION: v1.50.0
       YAEGI_VERSION: v0.14.2
       CGO_ENABLED: 0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,8 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GO_VERSION: 1.23
-      GOLANGCI_LINT_VERSION: v1.50.0
-      YAEGI_VERSION: v0.14.2
+      GOLANGCI_LINT_VERSION: v1.61.1
+      YAEGI_VERSION: v0.16.1
       CGO_ENABLED: 0
     defaults:
       run:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -29,17 +29,7 @@ linters-settings:
 linters:
   enable-all: true
   disable:
-    - deadcode # deprecated
-    - exhaustivestruct # deprecated
-    - golint # deprecated
-    - ifshort # deprecated
-    - interfacer # deprecated
-    - maligned # deprecated
-    - nosnakecase # deprecated
-    - scopelint # deprecated
-    - scopelint # deprecated
-    - structcheck # deprecated
-    - varcheck # deprecated
+    - exportloopref # deprecated
     - sqlclosecheck # not relevant (SQL)
     - rowserrcheck # not relevant (SQL)
     - execinquery # not relevant (SQL)
@@ -53,9 +43,8 @@ linters:
     - wsl
     - exhaustive
     - exhaustruct
-    - goerr113
+    - err113
     - wrapcheck
-    - ifshort
     - noctx
     - lll
     - gomnd

--- a/demo.go
+++ b/demo.go
@@ -4,7 +4,7 @@ package plugindemo
 import (
 	"bytes"
 	"context"
-	"fmt"
+	"errors"
 	"net/http"
 	"text/template"
 )
@@ -32,7 +32,7 @@ type Demo struct {
 // New created a new Demo plugin.
 func New(ctx context.Context, next http.Handler, config *Config, name string) (http.Handler, error) {
 	if len(config.Headers) == 0 {
-		return nil, fmt.Errorf("headers cannot be empty")
+		return nil, errors.New("headers cannot be empty")
 	}
 
 	return &Demo{

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/traefik/plugindemo
 
-go 1.19
+go 1.23
+
+toolchain go1.23.1


### PR DESCRIPTION
Hi, I tried to make a plugin by myself and noticed Go itself and several tools version are old so I updated.

## Updated tools

- Go 1.19 -> 1.23 (`go mod tidy -go=1.23`)
- golangci-lint v1.50.0 -> v1.61.1
- yaegi 0.14.2 -> v0.16.1

## Updated tool settings

- golangci-lint
  - Update deprecated/deactivated linters.
  - replace `goerr133` to `err133`
  - replaced `fmt.Errorf` to `errors.New` 

# Other

Maybe we can use `package plugindemo` instead of `package plugindemo_test` for `demo_test.go` since golangci-lint detects `depguard`?